### PR TITLE
Adding "end" event when recorder stops

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function createRecordStream (media, opts) {
   rs.recorder.addEventListener('dataavailable', function (ev) {
     push(ev.data)
   })
+  rs.recorder.onstop = () => rs.emit('end')
   rs.recorder.start(opts.interval || 1000)
 
   return rs


### PR DESCRIPTION
Per the spec https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
