### PR TITLE
Adding stop() method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function createRecordStream (media, opts) {
   }
 
   rs.stop = function () {
-    rs.once('data', () => rs.emit('end'))
+    rs.once('data', () => rs.push(null))
     rs.recorder.stop()
   }
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ function createRecordStream (media, opts) {
     rs.media = null
   }
 
+  rs.stop = function () {
+    rs.once('data', () => rs.emit('end'))
+    rs.recorder.stop()
+  }
+
   rs.media = media
   rs.recorder = new window.MediaRecorder(media, opts)
   rs.recorder.addEventListener('dataavailable', function (ev) {


### PR DESCRIPTION
It turns out that cleanly stoping and emitting end is a little tricky, this method helps. I've tested it in my app a bunch of times and it has never failed to end.
